### PR TITLE
Extensions

### DIFF
--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/helper/ViewHelper.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/helper/ViewHelper.java
@@ -42,12 +42,13 @@ public class ViewHelper {
         return mBaseView;
     }
 
-    public RecyclerView generateMenuView() {
+    public RecyclerView generateMenuView(boolean enableNestedScrolling) {
         //Create menu view
         RecyclerView mMenuView = new RecyclerView(mContext);
         mMenuView.setOverScrollMode(RecyclerView.OVER_SCROLL_NEVER);
         mMenuView.setBackgroundColor(Color.TRANSPARENT);
         mMenuView.setLayoutParams(matchParams);
+        mMenuView.setNestedScrollingEnabled(enableNestedScrolling);
         return mMenuView;
     }
 

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/listeners/OnFABMenuSelectedListener.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/listeners/OnFABMenuSelectedListener.java
@@ -3,5 +3,5 @@ package com.hlab.fabrevealmenu.listeners;
 import android.view.View;
 
 public interface OnFABMenuSelectedListener {
-    void onMenuItemSelected(View view);
+    void onMenuItemSelected(View view, int id);
 }

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/model/FABMenuItem.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/model/FABMenuItem.java
@@ -8,6 +8,7 @@ public class FABMenuItem {
     private String title;
     private Drawable iconDrawable;
     private Bitmap iconBitmap;
+    private boolean enabled = true;
 
     public FABMenuItem(String title, Drawable iconDrawable) {
         this.title = title;
@@ -51,6 +52,14 @@ public class FABMenuItem {
 
     public Bitmap getIconBitmap() {
         return iconBitmap;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 
 }

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/DynamicGridLayoutManager.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/DynamicGridLayoutManager.java
@@ -21,6 +21,10 @@ public class DynamicGridLayoutManager extends GridLayoutManager {
         super.onLayoutChildren(recycler, state);
     }
 
+    public void updateTotalItems(int totalItems) {
+        this.totalItems = totalItems;
+    }
+
     private void updateSpanCount() {
         int spanCount = 1;
         if (minItemWidth != 0) {

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABMenuAdapter.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABMenuAdapter.java
@@ -1,5 +1,6 @@
 package com.hlab.fabrevealmenu.view;
 
+import android.content.res.ColorStateList;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -29,6 +30,7 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
     private int rowLayoutResId = 0;
     private boolean showTitle = false;
     private int titleTextColor;
+    private int titleDisabledTextColor;
     private Direction direction;
     private boolean isCircularShape;
 
@@ -38,7 +40,7 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
     private int lastAnimatedPosition = -1;
     private int maxDuration;
 
-    public FABMenuAdapter(FABRevealMenu parent, List<FABMenuItem> mItems, int rowLayoutResId, boolean isCircularShape, int titleTextColor,
+    public FABMenuAdapter(FABRevealMenu parent, List<FABMenuItem> mItems, int rowLayoutResId, boolean isCircularShape, int titleTextColor, int titleDisabledTextColor,
                           boolean showTitle, Direction direction, boolean animateItems) {
         this.parent = parent;
         this.mItems = mItems;
@@ -46,6 +48,7 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
         this.isCircularShape = isCircularShape;
         this.showTitle = showTitle;
         this.titleTextColor = titleTextColor;
+        this.titleDisabledTextColor = titleDisabledTextColor;
         this.animateItems = animateItems;
         this.direction = direction;
     }
@@ -60,6 +63,7 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
     public void onBindViewHolder(ViewHolder holder, int position) {
         holder.setData(mItems.get(position));
         holder.itemView.setEnabled(mItems.get(position).isEnabled());
+        holder.tvTitle.setEnabled(mItems.get(position).isEnabled());
         // Here you apply the animation when the view is bound
         runEnterAnimation(holder.itemView, position);
     }
@@ -105,7 +109,7 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
             super(itemView);
             viewParent = (RelativeLayout) itemView.findViewById(R.id.view_parent);
             tvTitle = (TextView) itemView.findViewById(R.id.txt_title_menu_item);
-            tvTitle.setTextColor(titleTextColor);
+            tvTitle.setTextColor(new ColorStateList(new int[][] { new int[] { android.R.attr.state_enabled}, new int[] {-android.R.attr.state_enabled}}, new int[]{titleTextColor, titleDisabledTextColor}));
             tvTitle.setVisibility(showTitle ? View.VISIBLE : View.GONE);
             imgIcon = (ImageView) itemView.findViewById(R.id.img_menu_item);
 
@@ -194,6 +198,10 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
 
     public void setTitleTextColor(int titleTextColor) {
         this.titleTextColor = titleTextColor;
+    }
+
+    public void setTitleDisabledTextColor(int titleDisabledTextColor) {
+        this.titleDisabledTextColor = titleDisabledTextColor;
     }
 
     public Direction getDirection() {

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABMenuAdapter.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABMenuAdapter.java
@@ -59,6 +59,7 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
         holder.setData(mItems.get(position));
+        holder.itemView.setEnabled(mItems.get(position).isEnabled());
         // Here you apply the animation when the view is bound
         runEnterAnimation(holder.itemView, position);
     }
@@ -66,6 +67,31 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
     @Override
     public int getItemCount() {
         return mItems.size();
+    }
+
+    public FABMenuItem getItemByIndex(int index) {
+        if (index >= 0 && index < mItems.size()) {
+            return mItems.get(index);
+        }
+        return null;
+    }
+
+    public FABMenuItem getItemById(int id) {
+        for (int i = 0; i < mItems.size(); i++) {
+            if (mItems.get(i).getId() == id) {
+                return mItems.get(i);
+            }
+        }
+        return null;
+    }
+
+    public void notifyItemChangedById(int id) {
+        for (int i = 0; i < mItems.size(); i++) {
+            if (mItems.get(i).getId() == id) {
+                notifyItemChanged(i);
+                return;
+            }
+        }
     }
 
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
@@ -80,6 +106,7 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
             viewParent = (RelativeLayout) itemView.findViewById(R.id.view_parent);
             tvTitle = (TextView) itemView.findViewById(R.id.txt_title_menu_item);
             tvTitle.setTextColor(titleTextColor);
+            tvTitle.setVisibility(showTitle ? View.VISIBLE : View.GONE);
             imgIcon = (ImageView) itemView.findViewById(R.id.img_menu_item);
 
             viewParent.setBackgroundResource(isCircularShape ?
@@ -94,16 +121,15 @@ public class FABMenuAdapter extends RecyclerView.Adapter<FABMenuAdapter.ViewHold
             viewParent.setTag(item.getId());
             tvTitle.setText(item.getTitle());
             imgIcon.setImageDrawable(item.getIconDrawable());
-            if (showTitle)
-                tvTitle.setVisibility(View.VISIBLE);
-            else
-                tvTitle.setVisibility(View.GONE);
+
         }
 
         @Override
         public void onClick(View v) {
-            parent.closeMenu();
-            parent.menuSelectedListener.onMenuItemSelected(v);
+            if (item.isEnabled()) {
+                parent.closeMenu();
+                parent.menuSelectedListener.onMenuItemSelected(v, item.getId());
+            }
         }
     }
 

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
@@ -50,6 +50,7 @@ public class FABRevealMenu extends FrameLayout {
     @BoolRes
     private boolean mShowTitle;
     private int mTitleTextColor;
+    private int mTitleDisabledTextColor;
 
     private boolean animateItems;
     //Common constants
@@ -118,6 +119,7 @@ public class FABRevealMenu extends FrameLayout {
 
             //title
             mTitleTextColor = a.getColor(R.styleable.FABRevealMenu_menuTitleTextColor, getColor(android.R.color.white));
+            mTitleDisabledTextColor = a.getColor(R.styleable.FABRevealMenu_menuTitleDisabledTextColor, getColor(android.R.color.darker_gray));
             mShowTitle = a.getBoolean(R.styleable.FABRevealMenu_showTitle, true);
             mShowOverlay = a.getBoolean(R.styleable.FABRevealMenu_showOverlay, true);
 
@@ -211,11 +213,11 @@ public class FABRevealMenu extends FrameLayout {
             //set layout manager
             if (mDirection == Direction.LEFT || mDirection == Direction.RIGHT) {
                 mMenuView.setLayoutManager(new DynamicGridLayoutManager(mContext, (int) mContext.getResources().getDimension(R.dimen.column_size), menuList.size()));
-                menuAdapter = new FABMenuAdapter(this, menuList, R.layout.row_horizontal_menu_item, true, mTitleTextColor, mShowTitle, mDirection, animateItems);
+                menuAdapter = new FABMenuAdapter(this, menuList, R.layout.row_horizontal_menu_item, true, mTitleTextColor, mTitleDisabledTextColor, mShowTitle, mDirection, animateItems);
             } else {
                 isCircularShape = !mShowTitle;
                 mMenuView.setLayoutManager(new DynamicGridLayoutManager(mContext, 0, 0));
-                menuAdapter = new FABMenuAdapter(this, menuList, R.layout.row_vertical_menu_item, isCircularShape, mTitleTextColor, mShowTitle, mDirection, animateItems);
+                menuAdapter = new FABMenuAdapter(this, menuList, R.layout.row_vertical_menu_item, isCircularShape, mTitleTextColor, mTitleDisabledTextColor, mShowTitle, mDirection, animateItems);
             }
             mMenuView.setAdapter(menuAdapter);
 
@@ -484,6 +486,13 @@ public class FABRevealMenu extends FrameLayout {
         this.mTitleTextColor = mTitleTextColor;
         if (menuAdapter != null) {
             menuAdapter.setTitleTextColor(mTitleTextColor);
+        }
+    }
+
+    public void setMenuTitleDisabledTextColor(@ColorRes int mTitleDisabledTextColor) {
+        this.mTitleDisabledTextColor = mTitleDisabledTextColor;
+        if (menuAdapter != null) {
+            menuAdapter.setTitleDisabledTextColor(mTitleDisabledTextColor);
         }
     }
 

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
@@ -63,6 +63,7 @@ public class FABRevealMenu extends FrameLayout {
     private FrameLayout mOverlayLayout = null;
     private RevealLinearLayout mRevealView = null;
     private RecyclerView mMenuView = null;
+    private boolean mEnableNestedScrolling = true;
     private CardView mBaseView = null;
     private FABMenuAdapter menuAdapter = null;
 
@@ -150,6 +151,10 @@ public class FABRevealMenu extends FrameLayout {
         setUpView(mCustomView, false);
     }
 
+    public void setNestedScrollingEnabled(boolean enabled) {
+        mEnableNestedScrolling = enabled;
+    }
+
     public void setMenu(@MenuRes int menuRes) {
         mCustomView = null;
         mMenuRes = menuRes;
@@ -207,7 +212,7 @@ public class FABRevealMenu extends FrameLayout {
 
     private void setUpMenuView() {
         if (menuList != null && menuList.size() > 0) {
-            mMenuView = viewHelper.generateMenuView();
+            mMenuView = viewHelper.generateMenuView(mEnableNestedScrolling);
 
             boolean isCircularShape = false;
             //set layout manager

--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
@@ -157,6 +157,15 @@ public class FABRevealMenu extends FrameLayout {
         setUpMenu(menu);
     }
 
+    public void updateMenu() {
+        mCustomView = null;
+        removeAllViews();
+        if (menuList.size() > 0) {
+            setUpMenuView();
+        } else
+            setMenu(mMenuRes);
+    }
+
     public void setMenuItems(ArrayList<FABMenuItem> menuList) throws NullPointerException {
         this.menuList = menuList;
 
@@ -275,6 +284,43 @@ public class FABRevealMenu extends FrameLayout {
 
     // --- action methods --- //
 
+    public FABMenuItem getItemByIndex(int index) {
+        if (menuAdapter != null) {
+            return menuAdapter.getItemByIndex(index);
+        }
+        return null;
+    }
+
+    public FABMenuItem getItemById(int id) {
+        if (menuAdapter != null) {
+            return menuAdapter.getItemById(id);
+        }
+        return null;
+    }
+
+    public boolean removeItem(int id) {
+        if (menuList != null) {
+            for (int i = 0; i < menuList.size(); i++) {
+                if (menuList.get(i).getId() == id) {
+                    menuList.remove(i);
+                    ((DynamicGridLayoutManager)mMenuView.getLayoutManager()).updateTotalItems(menuList.size());
+                    if (menuAdapter != null) {
+                        menuAdapter.notifyItemRemoved(i);
+                        menuAdapter.notifyItemRangeChanged(i, menuList.size());
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public void notifyItemChanged(int id) {
+        if (menuAdapter != null) {
+            menuAdapter.notifyItemChangedById(id);
+        }
+    }
+
     public void setOnFABMenuSelectedListener(OnFABMenuSelectedListener menuSelectedListener) {
         this.menuSelectedListener = menuSelectedListener;
     }
@@ -371,7 +417,7 @@ public class FABRevealMenu extends FrameLayout {
 
     private void recreateView() {
         if (mMenuRes != -1)
-            setMenu(mMenuRes);
+            updateMenu();
         else if (mCustomView != null)
             setCustomView(mCustomView);
         else if (menuList != null)

--- a/fabrevealmenu/src/main/res/layout/row_horizontal_menu_item.xml
+++ b/fabrevealmenu/src/main/res/layout/row_horizontal_menu_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/view_parent"
-    android:layout_width="@dimen/row_horizontal_size"
+    android:layout_width="@dimen/column_size"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:gravity="center"

--- a/fabrevealmenu/src/main/res/values/attrs.xml
+++ b/fabrevealmenu/src/main/res/values/attrs.xml
@@ -16,6 +16,7 @@
 
         <attr name="showTitle" format="boolean" />
         <attr name="menuTitleTextColor" format="color" />
+        <attr name="menuTitleDisabledTextColor" format="color" />
         <attr name="animateItems" format="boolean" />
     </declare-styleable>
 

--- a/fabrevealmenu/src/main/res/values/dimens.xml
+++ b/fabrevealmenu/src/main/res/values/dimens.xml
@@ -6,7 +6,7 @@
     <dimen name="menu_padding_vertical">20dp</dimen>
     <dimen name="menu_size_horizontal">38dp</dimen>
     <dimen name="menu_size_vertical">30dp</dimen>
-    <dimen name="column_size">50dp</dimen>
+    <dimen name="column_size">70dp</dimen>
     <dimen name="card_radius">3dp</dimen>
     <dimen name="extra_margin">7dp</dimen>
     <dimen name="menu_min_width">200dp</dimen>


### PR DESCRIPTION
I added/changed following:

- `OnFABMenuSelectedListener`: also hand on the item id
- `FABMenuItem`:
  - can be disabled now
  - new setting added: `menuTitleDisabledTextColor`
- `FABMenuAdapter`: 
  - `getItemByIndex`, `getItemById`, `notifyItemChangedById` functions added
  - `tvTitle.setVisibility` call optimised, must only be once, not on every bind
- `FABRevealMenu`: 
  - `getItemByIndex`, `getItemById`, `removeItem`, `notifyItemChanged` added
  - recreateView optimised: menu is not reinflated if it has already been inflated