### PR TITLE
Extracted a menu function for making it possible to extend FABRevealMenu

### DIFF
--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
@@ -168,8 +168,12 @@ public class FABRevealMenu extends FrameLayout {
         mMenuRes = menuRes;
         removeAllViews();
         Menu menu = new MenuBuilder(getContext());
-        new MenuInflater(getContext()).inflate(menuRes, menu);
+        inflateMenu(menuRes, menu);
         setUpMenu(menu);
+    }
+
+    protected void inflateMenu(@MenuRes int menuRes, Menu menu) {
+        new MenuInflater(getContext()).inflate(menuRes, menu);
     }
 
     public void updateMenu() {


### PR DESCRIPTION
**Why**

I'm using icons based on fonts in my whole app so I don't need any drawables in it. Namely I use this library:
https://github.com/mikepenz/Android-Iconics/

I recently created a menu inflation wrapper that allows to use the font based icons in menus as well and therefore I would need the change I made.

**Usage**

If someone wants to use iconics with your library he must simply create following class and can use it in xml:

	public class IconicsFABRevealMenu extends FABRevealMenu
	{
		public IconicsFABRevealMenu(Context context)
		{
			super(context);
		}

		public IconicsFABRevealMenu(Context context, AttributeSet attrs)
		{
			super(context, attrs);
		}

		public IconicsFABRevealMenu(Context context, AttributeSet attrs, int defStyleAttr)
		{
			super(context, attrs, defStyleAttr);
		}

		protected void inflateMenu(@MenuRes int menuRes, Menu menu) {
			IconicsMenuInflatorUtil.inflate(new MenuInflater(getContext()), getContext(), menuRes, menu);
		}
	}