### PR TITLE
removed all handlers from FABRevealMenu and use the view's one instead

### DIFF
--- a/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
+++ b/fabrevealmenu/src/main/java/com/hlab/fabrevealmenu/view/FABRevealMenu.java
@@ -184,8 +184,12 @@ public class FABRevealMenu extends FrameLayout {
         removeAllViews();
         @SuppressLint("RestrictedApi")
         Menu menu = new MenuBuilder(getContext());
-        new MenuInflater(getContext()).inflate(menuRes, menu);
+        inflateMenu(menuRes, menu);
         setUpMenu(menu);
+    }
+
+    protected void inflateMenu(@MenuRes int menuRes, Menu menu) {
+        new MenuInflater(getContext()).inflate(menuRes, menu);
     }
 
     public void updateMenu() {
@@ -393,7 +397,7 @@ public class FABRevealMenu extends FrameLayout {
             });
 
             // Show sheet after a delay
-            new Handler().postDelayed(() -> {
+            postDelayed(() -> {
                 int finalRadius = Math.max(mBaseView.getWidth(), mBaseView.getHeight());
                 animationHelper.revealMenu(mBaseView, mFab.getWidth() / 2, finalRadius, false, new AnimationListener() {
                     @Override
@@ -445,7 +449,7 @@ public class FABRevealMenu extends FrameLayout {
             });
 
             // Show FAB after a delay
-            new Handler().postDelayed(() -> animationHelper.moveFab(mFab, mRevealView, mDirection, true, new AnimationListener() {
+            postDelayed(() -> animationHelper.moveFab(mFab, mRevealView, mDirection, true, new AnimationListener() {
                 @Override
                 public void onStart() {
                     mFab.setVisibility(View.VISIBLE);
@@ -492,7 +496,7 @@ public class FABRevealMenu extends FrameLayout {
     public void setShowOverlay(boolean mShowOverlay) {
         this.mShowOverlay = mShowOverlay;
         closeMenu();
-        new Handler().post(this::recreateView);
+        post(this::recreateView);
     }
 
     private boolean isMenuSmall() {
@@ -505,7 +509,7 @@ public class FABRevealMenu extends FrameLayout {
     public void enableItemAnimation(boolean enabled) {
         animateItems = enabled;
         if (menuAdapter != null) {
-            new Handler().post(() -> {
+            post(() -> {
                 menuAdapter.setAnimateItems(enabled);
                 menuAdapter.notifyDataSetChanged();
             });
@@ -517,7 +521,7 @@ public class FABRevealMenu extends FrameLayout {
      */
     public void setSmallerMenu() {
         mMenuSize = FAB_MENU_SIZE_SMALL;
-        new Handler().post(this::recreateView);
+        post(this::recreateView);
     }
 
     /**
@@ -525,7 +529,7 @@ public class FABRevealMenu extends FrameLayout {
      */
     public void setNormalMenu() {
         mMenuSize = FAB_MENU_SIZE_NORMAL;
-        new Handler().post(this::recreateView);
+        post(this::recreateView);
     }
 
     public void setTitleVisible(boolean mShowTitle) {
@@ -537,7 +541,7 @@ public class FABRevealMenu extends FrameLayout {
                 mBaseView.setMinimumWidth(LayoutParams.WRAP_CONTENT);
             menuAdapter.setShowTitle(mShowTitle);
             closeMenu();
-            new Handler().post(this::recreateView);
+            post(this::recreateView);
         }
     }
 
@@ -565,14 +569,14 @@ public class FABRevealMenu extends FrameLayout {
         this.mDirection = mDirection;
         if (menuAdapter != null) {
             menuAdapter.setDirection(mDirection);
-            new Handler().post(this::recreateView);
+            post(this::recreateView);
         }
     }
 
     public void setMenuTitleTypeface(Typeface mMenuTitleTypeface) {
         if (mMenuTitleTypeface != null) {
             this.mMenuTitleTypeface = mMenuTitleTypeface;
-            new Handler().post(this::recreateView);
+            post(this::recreateView);
         }
     }
 }

--- a/fabrevealmenu/src/main/res/layout/row_horizontal_menu_item.xml
+++ b/fabrevealmenu/src/main/res/layout/row_horizontal_menu_item.xml
@@ -23,7 +23,7 @@
         android:layout_centerHorizontal="true"
         android:layout_marginTop="5dp"
         android:gravity="center"
-        android:maxLines="1"
+        android:maxLines="@integer/horizontal_menu_max_lines"
         android:textColor="@android:color/white"
         android:textSize="@dimen/menu_text_size_horizontal"
         android:visibility="gone" />

--- a/fabrevealmenu/src/main/res/layout/row_horizontal_menu_item_small.xml
+++ b/fabrevealmenu/src/main/res/layout/row_horizontal_menu_item_small.xml
@@ -23,7 +23,7 @@
         android:layout_centerHorizontal="true"
         android:layout_marginTop="5dp"
         android:gravity="center"
-        android:maxLines="1"
+        android:maxLines="@integer/horizontal_menu_max_lines"
         android:textColor="@android:color/white"
         android:textSize="@dimen/menu_text_size_horizontal_small"
         android:visibility="gone" />

--- a/fabrevealmenu/src/main/res/values/integers.xml
+++ b/fabrevealmenu/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="horizontal_menu_max_lines">1</integer>
+</resources>


### PR DESCRIPTION
I made following adjustments:

* removed all usages of `new Handler()` in the `FABRevealMenu` => instead I'm posting every runnable to the view's internal one so that they are queued up correctly and this also avoid creating new handlers for each call
* added abiltiy to use a custom menu inflater => if this single line of change is a problem, please explain me why

The first thing also solves bugs that happen if you recreate the view at runtime, which currently sometimes messes up layouts (i.e. changing menu direction after view inflation)